### PR TITLE
Minor upgrades to ensure compatibility with latest shipyard master

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "shipyard_hierarchy"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["David Komer <david.komer@gmail.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Hierarchy for Shipyard Entity Component System"
 keywords = ["ecs", "entity", "component", "hierarchy"]
@@ -13,12 +13,12 @@ repository = "https://github.com/dakom/shipyard-hierarchy"
 [dependencies]
 
 #SOON: shipyard = { version = "^0.5", default-features = false}
-shipyard = { git = "https://github.com/leudz/shipyard", default-features = false }
+[dependencies.shipyard]
+git = "https://github.com/leudz/shipyard"
+default-features = false
 
-[features]
-default = ["shipyard/default"]
-parallel = ["shipyard/parallel"]
-non_send = ["shipyard/non_send"]
-non_sync = ["shipyard/non_sync"]
-wasm = ["shipyard/wasm"]
-std = ["shipyard/std"]
+[dev-dependencies.shipyard]
+git = "https://github.com/leudz/shipyard"
+default-features = false
+# Required for hierarchy tests that use World::new
+features = ["std"]

--- a/src/components.rs
+++ b/src/components.rs
@@ -7,6 +7,12 @@ pub struct Parent <T>{
     marker: PhantomData<T>
 }
 
+impl <T> Component for Parent<T> where T: 'static {
+
+    // TODO: #HIGH Uncertain what kind of tracking this needs. Same for Child
+    type Tracking = track::All;
+}
+
 impl <T> Parent<T> {
     pub fn new(num_children: usize, first_child: EntityId) -> Self {
         Self {
@@ -22,6 +28,11 @@ pub struct Child <T>{
     pub prev: EntityId,
     pub next: EntityId,
     marker: PhantomData<T>
+}
+
+impl <T> Component for Child<T> where T: 'static {
+
+    type Tracking = track::All;
 }
 
 impl <T> Child <T> {

--- a/tests/test_hierarchy_basic.rs
+++ b/tests/test_hierarchy_basic.rs
@@ -1,3 +1,7 @@
+
+#[cfg(test)]
+mod tests {
+
 use shipyard::*;
 use shipyard_hierarchy::*;
 use std::collections::HashMap;
@@ -53,12 +57,18 @@ fn test_hierarchy() {
     }
 }
 
-
 #[test]
 fn test_sorting_depth_first() {
+
+    #[derive(PartialEq, Eq, Debug, PartialOrd, Ord)]
+    struct USIZE(usize);
+    impl Component for USIZE {
+        type Tracking = track::Untracked;
+    }
+
     let world = World::new();
 
-    let (mut hierarchy, mut usizes) = world.borrow::<((EntitiesViewMut, ViewMut<Parent<MyTree>>, ViewMut<Child<MyTree>>), ViewMut<usize>)>().unwrap();
+    let (mut hierarchy, mut usizes) = world.borrow::<((EntitiesViewMut, ViewMut<Parent<MyTree>>, ViewMut<Child<MyTree>>), ViewMut<USIZE>)>().unwrap();
 
     let mut hierarchy = (&mut hierarchy.0, &mut hierarchy.1, &mut hierarchy.2);
 
@@ -75,11 +85,11 @@ fn test_sorting_depth_first() {
 
     {
         let entities = &mut hierarchy.0;
-        entities.add_component(e0, &mut usizes, 7);
-        entities.add_component(e1, &mut usizes, 5);
-        entities.add_component(e2, &mut usizes, 6);
-        entities.add_component(e3, &mut usizes, 1);
-        entities.add_component(e4, &mut usizes, 3);
+        entities.add_component(e0, &mut usizes, USIZE(7));
+        entities.add_component(e1, &mut usizes, USIZE(5));
+        entities.add_component(e2, &mut usizes, USIZE(6));
+        entities.add_component(e3, &mut usizes, USIZE(1));
+        entities.add_component(e4, &mut usizes, USIZE(3));
     }
 
     {
@@ -239,16 +249,17 @@ fn test_debug_print() {
     }
 }
 
+// TODO: Consider future proofing the expected syntax here as EntityId's Debug syntax has changed and may change again.
 const EXPECTED_DEBUG_TREE_1:&'static str = 
-r#"EntityId { index: 0, gen: 0 }
-  EntityId { index: 1, gen: 0 }
-    EntityId { index: 3, gen: 0 }
-    EntityId { index: 4, gen: 0 }
-  EntityId { index: 2, gen: 0 }
-    EntityId { index: 5, gen: 0 }
-      EntityId { index: 7, gen: 0 }
-    EntityId { index: 6, gen: 0 }
-      EntityId { index: 8, gen: 0 }
+r#"EId(0.0)
+  EId(1.0)
+    EId(3.0)
+    EId(4.0)
+  EId(2.0)
+    EId(5.0)
+      EId(7.0)
+    EId(6.0)
+      EId(8.0)
 "#;
 
 const EXPECTED_DEBUG_TREE_2:&'static str =
@@ -268,3 +279,5 @@ r#"root
           n
       k
 "#;
+
+}


### PR DESCRIPTION
Hi,

It seems that the latest release on crates.io is not compatible with the latest shipyard release or the latest shipyard master branch. This is mainly related to feature names changing in shipyard and also a new requirement to manually implement ```Component``` and a tracking associated type (Which I've now done for your tests).

No problem if you can't accept this for whatever reason but hopefully it highlights the relevant parts that have fallen behind if you want to do this yourself.